### PR TITLE
OPS-6327 Remove caller identity from OSS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,6 @@ resource "aws_opensearchserverless_access_policy" "data_policy" {
       ],
       Principal = concat([
         aws_iam_role.knowledgebase.arn,
-        data.aws_caller_identity.this.arn
         ],
         var.oss_additional_roles_arns
       )


### PR DESCRIPTION
Use `oss_additional_roles_arns` parameter instead.