### PR TITLE
OPS-6934 refactor iam bedrock permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,50 @@ object({
 
 Default: `null`
 
+### <a name="input_additional_agent_policy_statements"></a> [additional\_agent\_policy\_statements](#input\_additional\_agent\_policy\_statements)
+
+Description: Optional additional IAM policy statements for the Bedrock agent role
+
+Type:
+
+```hcl
+list(object({
+    sid       = optional(string)
+    actions   = list(string)
+    resources = list(string)
+    effect    = optional(string, "Allow")
+    condition = optional(list(object({
+      test     = string
+      variable = string
+      values   = list(string)
+    })))
+  }))
+```
+
+Default: `[]`
+
+### <a name="input_additional_knowledgebase_policy_statements"></a> [additional\_knowledgebase\_policy\_statements](#input\_additional\_knowledgebase\_policy\_statements)
+
+Description: Optional additional IAM policy statements for the Bedrock knowledge base role
+
+Type:
+
+```hcl
+list(object({
+    sid       = optional(string)
+    actions   = list(string)
+    resources = list(string)
+    effect    = optional(string, "Allow")
+    condition = optional(list(object({
+      test     = string
+      variable = string
+      values   = list(string)
+    })))
+  }))
+```
+
+Default: `[]`
+
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
 Description: A map of tags to assign to the customization job and custom model.

--- a/data.tf
+++ b/data.tf
@@ -18,6 +18,7 @@ data "aws_bedrock_foundation_model" "knowledgebase" {
 
 data "aws_iam_policy_document" "agent_trust" {
   statement {
+    sid     = "AllowBedrockAgentAssumeRole"
     actions = ["sts:AssumeRole"]
     principals {
       identifiers = ["bedrock.amazonaws.com"]
@@ -38,6 +39,7 @@ data "aws_iam_policy_document" "agent_trust" {
 
 data "aws_iam_policy_document" "agent_permissions" {
   statement {
+    sid     = "AllowInvokeModelAndStream"
     actions = [
       "bedrock:InvokeModel",
       "bedrock:InvokeModelWithResponseStream"
@@ -47,6 +49,7 @@ data "aws_iam_policy_document" "agent_permissions" {
     ]
   }
   statement {
+    sid     = "AllowRetrieveFromKnowledgeBase"
     actions = ["bedrock:Retrieve"]
     resources = [
       aws_bedrockagent_knowledge_base.this.arn
@@ -56,6 +59,7 @@ data "aws_iam_policy_document" "agent_permissions" {
 
 data "aws_iam_policy_document" "knowledgebase_trust" {
   statement {
+    sid     = "AllowBedrockKnowledgeBaseAssumeRole"
     actions = ["sts:AssumeRole"]
     principals {
       identifiers = ["bedrock.amazonaws.com"]
@@ -76,6 +80,7 @@ data "aws_iam_policy_document" "knowledgebase_trust" {
 
 data "aws_iam_policy_document" "knowledgebase_permissions" {
   statement {
+    sid     = "AllowInvokeModel"
     actions = [
       "bedrock:InvokeModel"
     ]
@@ -91,12 +96,14 @@ data "aws_iam_policy_document" "knowledgebase_permissions" {
     resources = ["*"]
   }
   statement {
+    sid     = "AllowOpenSearchAccess"
     actions = ["aoss:APIAccessAll"]
     resources = [
       aws_opensearchserverless_collection.this.arn
     ]
   }
   statement {
+    sid     = "AllowS3ListBucket"
     actions = ["s3:ListBucket"]
     resources = [
       var.s3_configuration.bucket_arn
@@ -108,6 +115,7 @@ data "aws_iam_policy_document" "knowledgebase_permissions" {
     }
   }
   statement {
+    sid     = "AllowS3GetObject"
     actions = ["s3:GetObject"]
     resources = var.s3_configuration.inclusion_prefixes == null ? [
       "${var.s3_configuration.bucket_arn}/*"

--- a/data.tf
+++ b/data.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "agent_trust" {
 
 data "aws_iam_policy_document" "agent_permissions" {
   statement {
-    sid     = "AllowInvokeModelAndStream"
+    sid = "AllowInvokeModelAndStream"
     actions = [
       "bedrock:InvokeModel",
       "bedrock:InvokeModelWithResponseStream"
@@ -99,7 +99,7 @@ data "aws_iam_policy_document" "knowledgebase_trust" {
 
 data "aws_iam_policy_document" "knowledgebase_permissions" {
   statement {
-    sid     = "AllowInvokeModel"
+    sid = "AllowInvokeModel"
     actions = [
       "bedrock:InvokeModel"
     ]
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "knowledgebase_permissions" {
     ]
   }
   statement {
-    sid     = "AllowRerank"
+    sid = "AllowRerank"
     actions = [
       "bedrock:Rerank"
     ]

--- a/data.tf
+++ b/data.tf
@@ -55,6 +55,25 @@ data "aws_iam_policy_document" "agent_permissions" {
       aws_bedrockagent_knowledge_base.this.arn
     ]
   }
+
+  dynamic "statement" {
+    for_each = var.additional_agent_policy_statements
+    content {
+      sid       = try(statement.value.sid, null)
+      effect    = try(statement.value.effect, "Allow")
+      actions   = statement.value.actions
+      resources = statement.value.resources
+
+      dynamic "condition" {
+        for_each = statement.value.condition != null ? statement.value.condition : []
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "knowledgebase_trust" {
@@ -126,6 +145,25 @@ data "aws_iam_policy_document" "knowledgebase_permissions" {
       test     = "StringEquals"
       values   = [data.aws_caller_identity.this.account_id]
       variable = "aws:ResourceAccount"
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.additional_knowledgebase_policy_statements
+    content {
+      sid       = try(statement.value.sid, null)
+      effect    = try(statement.value.effect, "Allow")
+      actions   = statement.value.actions
+      resources = statement.value.resources
+
+      dynamic "condition" {
+        for_each = statement.value.condition != null ? statement.value.condition : []
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
     }
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -77,12 +77,18 @@ data "aws_iam_policy_document" "knowledgebase_trust" {
 data "aws_iam_policy_document" "knowledgebase_permissions" {
   statement {
     actions = [
-      "bedrock:InvokeModel",
-      "bedrock:Rerank"
+      "bedrock:InvokeModel"
     ]
     resources = [for id in local.knowledgebase_access_model_ids :
       data.aws_bedrock_foundation_model.knowledgebase[id].model_arn
     ]
+  }
+  statement {
+    sid     = "AllowRerank"
+    actions = [
+      "bedrock:Rerank"
+    ]
+    resources = ["*"]
   }
   statement {
     actions = ["aoss:APIAccessAll"]

--- a/variables.tf
+++ b/variables.tf
@@ -487,7 +487,37 @@ variable "guardrail_config" {
   })
   default = null
 }
+variable "additional_agent_policy_statements" {
+  description = "Optional additional IAM policy statements for the Bedrock agent role"
+  type = list(object({
+    sid       = optional(string)
+    actions   = list(string)
+    resources = list(string)
+    effect    = optional(string, "Allow")
+    condition = optional(list(object({
+      test     = string
+      variable = string
+      values   = list(string)
+    })))
+  }))
+  default = []
+}
 
+variable "additional_knowledgebase_policy_statements" {
+  description = "Optional additional IAM policy statements for the Bedrock knowledge base role"
+  type = list(object({
+    sid       = optional(string)
+    actions   = list(string)
+    resources = list(string)
+    effect    = optional(string, "Allow")
+    condition = optional(list(object({
+      test     = string
+      variable = string
+      values   = list(string)
+    })))
+  }))
+  default = []
+}
 
 variable "tags" {
   description = "A map of tags to assign to the customization job and custom model."


### PR DESCRIPTION
# ✨ Changes
- **Added Sid fields** to all IAM statements for consistency and audit clarity.
- **Fixed bedrock:Rerank statement** to use Resource = "*", as the action does not support resource-level permissions.
- **Introduced new variables**:
  - additional_agent_policy_statements
  - additional_knowledgebase_policy_statements
   
  → Allow users to append custom IAM statements dynamically via Terraform variables.

